### PR TITLE
Create rule ExistsByHash

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,19 @@ User::idToHash($id);
 // convert hash to id from User static instance;
 User::hashToId($hash);
 ```
+
+#### Rules / Validation
+```php
+use Veelasky\LaravelHashId\Rules\ExistsByHash;
+
+...
+
+$this->validate($this->request, [
+    'name' => 'required',
+    'description' => 'nullable',
+    'products.*.hash' => ['required', new ExistsByHash(Product::class)],
+]);
+
+...
+```
+`Product::class` is an eloquent model that use `HashableId` Trait.  

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "hashids/hashids": "^2.0",
         "illuminate/contracts": ">=5.5",
         "illuminate/config": ">=5.5",
-        "illuminate/support": ">=5.5"
+        "illuminate/support": ">=5.5",
+        "illuminate/validation": "^5.5|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Eloquent/HashableId.php
+++ b/src/Eloquent/HashableId.php
@@ -8,6 +8,9 @@ use Veelasky\LaravelHashId\Repository as HashRepository;
  * Eloquent Model Hashable Id.
  *
  * @author      veelasky <veelasky@gmail.com>
+ *
+ * @method static \Illuminate\Database\Eloquent\Model|object|static|null byHash(string $hash)
+ * @method static \Illuminate\Database\Eloquent\Model|static byHashOrFail(string $hash)
  */
 trait HashableId
 {

--- a/src/Rules/ExistsByHash.php
+++ b/src/Rules/ExistsByHash.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Veelasky\LaravelHashId\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class ExistsByHash implements Rule
+{
+    /**
+     * @var string
+     */
+    private $model;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @param string $model
+     */
+    public function __construct(string $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return $this->model::query()->where('id', $this->model::HashtoId($value))->count() > 0;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return trans('validation.exists');
+    }
+}


### PR DESCRIPTION
since we can't use laravel `exists` validation as a validation rule because the request will contains _hash_ instead of _id_. i think it should be useful if we adding `Rule Validation` here.