### PR TITLE
Fixed not-unique salt

### DIFF
--- a/src/Eloquent/HashableId.php
+++ b/src/Eloquent/HashableId.php
@@ -94,10 +94,20 @@ trait HashableId
         if ($repository->has($this->getTable())) {
             return $repository->get($this->getTable());
         }
-        $salted = substr(strrev(self::class), 0, 4).substr(env('APP_KEY'), 0, 4);
+
         // ... create a new hashid instance if it not existed
-        $hash = $repository->make($this->getTable(), $salted);
+        $hash = $repository->make($this->getTable(), $this->makeHashedIdSalt());
 
         return $hash;
+    }
+
+    /**
+     * Make a unique hash for the trait-using class.
+     *
+     * @return string
+     */
+    protected function makeHashedIdSalt()
+    {
+        return substr(strrev(self::class), 0, 4).substr(config('app.key', 'lara'), -4);
     }
 }


### PR DESCRIPTION
**Fixed a bug that the salt might not be unique per application.**
The salt was generated with the first 4 letters of the application key. Since more than 2 years, the key is prepended with `base64:`, which means the salt for nearly every application might be "base" and the class name.

**Increased performance**
While `env()` reads the environment file, `config()` can access the apps config-variable and therefore is much faster. Therefore, the env-helper should never be used in application code, only to resolve config in the first place.

**Allow easy overwrite for the salt generation method**
Because of the changed behaviour, the salt for a lot of implementations would change. Therefore, we should provide an easy method to revert the salt-generation method. This is done with the implementation of `makeHashedIdSalt` which can be overridden in the trait-using model.