### PR TITLE
Fixed abstract inheritance

### DIFF
--- a/src/Eloquent/HashableId.php
+++ b/src/Eloquent/HashableId.php
@@ -94,10 +94,20 @@ trait HashableId
         if ($repository->has($this->getTable())) {
             return $repository->get($this->getTable());
         }
-        $salted = substr(strrev(self::class), 0, 4).substr(env('APP_KEY'), 0, 4);
+
         // ... create a new hashid instance if it not existed
-        $hash = $repository->make($this->getTable(), $salted);
+        $hash = $repository->make($this->getTable(), $this->makeHashedIdSalt());
 
         return $hash;
+    }
+
+    /**
+     * Make a unique hash for the trait-using class.
+     *
+     * @return string
+     */
+    protected function makeHashedIdSalt()
+    {
+        return substr(strrev(self::class), 0, 4).substr(config('app.key', 'lara'), -4);
     }
 }

--- a/src/Eloquent/HashableId.php
+++ b/src/Eloquent/HashableId.php
@@ -108,6 +108,6 @@ trait HashableId
      */
     protected function makeHashedIdSalt()
     {
-        return substr(strrev(self::class), 0, 4).substr(config('app.key', 'lara'), -4);
+        return substr(static::class, -4).substr(config('app.key', 'lara'), -4);
     }
 }


### PR DESCRIPTION
This change includes PR #4 implicitely. You should merge PR #4 first.

**Fixed abstract inheritance**
With the `self`-construct, the trait-using class returned. If the trait is used in a `BaseModel`, which is extended, the salt is the same for all models. With the `static`-construct, the calling class is returned, which would usually be more accurate.

**Increased performance**
Changed two function call `substr(strrv())` to one function-call `substr()` with negative offet.