### PR TITLE
Route binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ class User extends Model {
 
 ```
 
+#### Route binding
+
+When HashableId trait is used, base getRouteKey() and resolveRouteBinding() are overwritten to use the HashId as route key.
+
+```php
+use App\Models\User;
+
+class UserController extends Controller
+{
+    /**
+     * Route /users/{user}
+     * Ex: GET /users/k1jTdv6l
+     */
+    public function show(User $user)
+    {
+        ...
+    }
+}
+```
+
 #### In-Depth Coverage
 
 This package use repository pattern to store all instantiated implementation of `HashId\HashId` class, this to achieve different hash result on every eloquent models defined with `HashableId` trait.

--- a/src/Eloquent/HashableId.php
+++ b/src/Eloquent/HashableId.php
@@ -33,7 +33,7 @@ trait HashableId
      */
     public function resolveRouteBinding($value, $field = null)
     {
-        if ($field) {
+        if ($field || is_numeric($value)) {
             return parent::resolveRouteBinding($value, $field);
         }
 

--- a/src/Eloquent/HashableId.php
+++ b/src/Eloquent/HashableId.php
@@ -29,6 +29,18 @@ trait HashableId
     }
 
     /**
+	 * @see parent
+	 */
+    public function resolveRouteBinding($value, $field = null)
+    {
+        if ($field) {
+            return parent::resolveRouteBinding($value, $field);
+        }
+
+        return $this->byHash($value);
+    }
+
+    /**
      * Get Model by hash.
      *
      * @param $hash

--- a/src/Eloquent/HashableId.php
+++ b/src/Eloquent/HashableId.php
@@ -29,8 +29,8 @@ trait HashableId
     }
 
     /**
-	 * @see parent
-	 */
+     * @see parent
+     */
     public function resolveRouteBinding($value, $field = null)
     {
         if ($field) {

--- a/tests/Unit/HashableIdModelTest.php
+++ b/tests/Unit/HashableIdModelTest.php
@@ -174,6 +174,15 @@ class HashableIdModelTest extends TestCase
         $this->assertEquals(CustomSaltModel::idToHash(1), $this->getRepository()->idToHash(1, 'custom'));
     }
 
+    public function test_route_binding()
+    {
+        $m = new HashModel();
+        $m->save();
+
+        $resolved = $m->resolveRouteBinding($m->hash);
+        $this->assertTrue($resolved->is($m));
+    }
+
     protected function getRepository(): Repository
     {
         return app('app.hashid');


### PR DESCRIPTION
Adds the possibility of dependency injection through Laravel's native route binding.

```php
use Illuminate\Database\Eloquent\Model;
use Veelasky\LaravelHashId\Eloquent\HashableId;

class User extends Model {
    use HashableId;
    ...
}
```

When HashableId trait is used, base getRouteKey() and resolveRouteBinding() are overwritten to use the HashId as route key.

```php
use App\Models\User;

class UserController extends Controller
{
    /**
     * Route /users/{user}
     * Ex: GET /users/k1jTdv6l
     */
    public function show(User $user)
    {
        ...
    }
}
```