### PR TITLE
Create Default HashId instance only if needed

### DIFF
--- a/src/HashIdServiceProvider.php
+++ b/src/HashIdServiceProvider.php
@@ -19,11 +19,6 @@ class HashIdServiceProvider extends LaravelServiceProvider
                 __DIR__.'/../config' => $this->app->basePath('config'),
             ], 'laravel-hashid-config');
         }
-
-        $this->app['app.hashid']->make(
-            'default',
-            substr($this->app['config']->get('app.key', $this->app['config']->get('hashid.hash_alphabet')), 8, 4).substr($this->app['config']->get('app.key', 'lara'), -4)
-        );
     }
 
     /**

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -59,8 +59,14 @@ class Repository implements RepositoryContract, ArrayAccess
             return $this->hashes[$key];
         }
 
-        $key = strlen($key) > 4 ? $key : 'default'.$key;
+        if ($key === 'default') {
+            return $this->make(
+                $key,
+                substr(config('app.key', config('hashid.hash_alphabet')), 8, 4).substr(config('app.key', 'lara'), -4)
+            );
+        }
 
+        $key = strlen($key) > 4 ? $key : 'default'.$key;
         return $this->make($key, substr($key, -4).substr(config('app.key', 'lara'), -4));
     }
 

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -67,6 +67,7 @@ class Repository implements RepositoryContract, ArrayAccess
         }
 
         $key = strlen($key) > 4 ? $key : 'default'.$key;
+
         return $this->make($key, substr($key, -4).substr(config('app.key', 'lara'), -4));
     }
 

--- a/tests/Unit/RepositoryTest.php
+++ b/tests/Unit/RepositoryTest.php
@@ -50,12 +50,13 @@ class RepositoryTest extends TestCase
         $this->assertArrayNotHasKey($key, $this->getRepository());
     }
 
-    public function test_should_has_one_on_start()
+    public function test_should_have_default()
     {
-        $this->assertCount(1, $this->getRepository()->all());
+        $default = $this->getRepository()->get('default');
 
-        // and it's default.
-        $this->assertArrayHasKey('default', $this->getRepository()->all());
+        $this->assertInstanceOf(Hashids::class, $default);
+
+        $this->assertEquals([1234], $default->decode('jXrJE9PL'));
     }
 
     protected function getRepository(): Repository


### PR DESCRIPTION
Currently, on every boot, the "Default" HashId Instance is created. This is expensive, and in most use cases unneccessary, as this default is seldomly used, as far as I understand.

Further, when using an environment without Math-libraries for `composer require veelasky/laravel-hashid` (for example the [Composer container](https://hub.docker.com/_/composer)), the `php artisan package:discover` command will fail, resulting in abortion of package discovery.

This change will delay the creation of the "Default" instance until it's required for the first time.